### PR TITLE
improved the nats queue

### DIFF
--- a/queues/nats/nats.go
+++ b/queues/nats/nats.go
@@ -98,9 +98,7 @@ func (t *Transport) makeSubscriber(name string) (chan []byte, error) {
 	}
 
 	sub, err := c.Subscribe(name, func(m *nats.Msg) {
-		data := m.Data
-		ch <- data
-		return
+		ch <- m.Data
 	})
 	if err != nil {
 		return nil, err

--- a/queues/nats/nats.go
+++ b/queues/nats/nats.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/matryer/vice"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 // DefaultAddr is the NATS default TCP address.
@@ -16,49 +16,63 @@ var _ vice.Transport = (*Transport)(nil)
 
 // Transport is a vice.Transport for NATS queue.
 type Transport struct {
-	rm           sync.Mutex
-	receiveChans map[string]chan []byte
+	*sync.Mutex
 
-	sm        sync.Mutex
-	sendChans map[string]chan []byte
+	receiveChans map[string]chan []byte
+	sendChans    map[string]chan []byte
 
 	errChan chan error
 	// stopchan is closed when everything has stopped.
-	stopchan chan struct{}
-	//stopPubChan chan struct{}
+	stopchan    chan struct{}
+	stopPubChan chan struct{}
 
 	subscriptions []*nats.Subscription
-	connections   []*nats.Conn
+	natsConn      *nats.Conn
 
 	// exported fields
 	NatsAddr string
 }
 
 // New returns a new Transport
-func New() *Transport {
+func New(opts ...Option) *Transport {
+	var options Options
+	for _, o := range opts {
+		o(&options)
+	}
+
 	return &Transport{
+		Mutex: &sync.Mutex{},
+
 		NatsAddr: DefaultAddr,
 
 		receiveChans: make(map[string]chan []byte),
 		sendChans:    make(map[string]chan []byte),
 
-		errChan:  make(chan error, 10),
-		stopchan: make(chan struct{}),
+		errChan:     make(chan error, 10),
+		stopchan:    make(chan struct{}),
+		stopPubChan: make(chan struct{}),
 
 		subscriptions: []*nats.Subscription{},
-		connections:   []*nats.Conn{},
+
+		natsConn: options.Conn,
 	}
 }
 
 func (t *Transport) newConnection() (*nats.Conn, error) {
-	return nats.Connect(t.NatsAddr)
+	var err error
+	if t.natsConn != nil {
+		return t.natsConn, nil
+	}
+
+	t.natsConn, err = nats.Connect(t.NatsAddr)
+	return t.natsConn, err
 }
 
 // Receive gets a channel on which to receive messages
 // with the specified name.
 func (t *Transport) Receive(name string) <-chan []byte {
-	t.rm.Lock()
-	defer t.rm.Unlock()
+	t.Lock()
+	defer t.Unlock()
 
 	ch := make(chan []byte)
 	ch, ok := t.receiveChans[name]
@@ -91,7 +105,6 @@ func (t *Transport) makeSubscriber(name string) (chan []byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	t.connections = append(t.connections, c)
 	t.subscriptions = append(t.subscriptions, sub)
 	return ch, nil
 }
@@ -99,8 +112,8 @@ func (t *Transport) makeSubscriber(name string) (chan []byte, error) {
 // Send gets a channel on which messages with the
 // specified name may be sent.
 func (t *Transport) Send(name string) chan<- []byte {
-	t.sm.Lock()
-	defer t.sm.Unlock()
+	t.Lock()
+	defer t.Unlock()
 
 	ch := make(chan []byte)
 	ch, ok := t.sendChans[name]
@@ -120,6 +133,7 @@ func (t *Transport) Send(name string) chan<- []byte {
 
 func (t *Transport) makePublisher(name string) (chan []byte, error) {
 	ch := make(chan []byte)
+
 	c, err := t.newConnection()
 	if err != nil {
 		return nil, err
@@ -128,16 +142,17 @@ func (t *Transport) makePublisher(name string) (chan []byte, error) {
 	go func() {
 		for {
 			select {
+			case <-t.stopPubChan:
+				return
 			case msg := <-ch:
 				if err := c.Publish(name, msg); err != nil {
 					t.errChan <- vice.Err{Message: msg, Name: name, Err: err}
-					continue
 				}
 			default:
 			}
 		}
 	}()
-	t.connections = append(t.connections, c)
+
 	return ch, nil
 }
 
@@ -150,12 +165,16 @@ func (t *Transport) ErrChan() <-chan error {
 // The channel returned from Done() will be closed
 // when the transport has stopped.
 func (t *Transport) Stop() {
+	t.Lock()
+	defer t.Unlock()
+
 	for _, s := range t.subscriptions {
 		s.Unsubscribe()
 	}
-	for _, conn := range t.connections {
-		conn.Close()
-	}
+
+	close(t.stopPubChan)
+	t.natsConn.Close()
+	t.natsConn = nil
 	close(t.stopchan)
 }
 

--- a/queues/nats/options.go
+++ b/queues/nats/options.go
@@ -1,0 +1,15 @@
+package nats
+
+import "github.com/nats-io/go-nats"
+
+type Options struct {
+	Conn *nats.Conn
+}
+
+type Option func(*Options)
+
+func WithConnection(c *nats.Conn) Option {
+	return func(o *Options) {
+		o.Conn = c
+	}
+}


### PR DESCRIPTION
  - fixed some race conditions (fixes #6)
  - clean up the publisher goroutines on stop
  - reuse the nats connection (fixes #4)
  - allow it to configure the underlying nats connection to make it
possible to connect to secure nats clusters etc.