### PR TITLE
nats: use buffered channels to improve performance

### DIFF
--- a/queues/nats/nats.go
+++ b/queues/nats/nats.go
@@ -90,7 +90,7 @@ func (t *Transport) Receive(name string) <-chan []byte {
 }
 
 func (t *Transport) makeSubscriber(name string) (chan []byte, error) {
-	ch := make(chan []byte)
+	ch := make(chan []byte, 1024)
 
 	c, err := t.newConnection()
 	if err != nil {
@@ -130,7 +130,7 @@ func (t *Transport) Send(name string) chan<- []byte {
 }
 
 func (t *Transport) makePublisher(name string) (chan []byte, error) {
-	ch := make(chan []byte)
+	ch := make(chan []byte, 1024)
 
 	c, err := t.newConnection()
 	if err != nil {


### PR DESCRIPTION
The nats performance improve a lot with this little change:

I changed the sendloop in test.go to this

```go
	for i := 0; i < 10000; i++ {
		msg := []byte(fmt.Sprintf("message %d", i+1))
		wg.Add(3)
		transport.Send("vicechannel1") <- msg
		transport.Send("vicechannel2") <- msg
		transport.Send("vicechannel3") <- msg
	}
```
to send 10000 messages instead of 100 down each channel

Before:
```
=== RUN   TestTransport
=== RUN   TestTransport/testStandardTransportBehaviour
=== RUN   TestTransport/testSendChannelsDontBlock
--- PASS: TestTransport (2.34s)
    --- PASS: TestTransport/testStandardTransportBehaviour (2.34s)
    --- PASS: TestTransport/testSendChannelsDontBlock (0.00s)
=== RUN   TestReceive
--- PASS: TestReceive (0.01s)
=== RUN   TestSend
--- PASS: TestSend (0.01s)
PASS
```

After:

```
=== RUN   TestTransport
=== RUN   TestTransport/testStandardTransportBehaviour
=== RUN   TestTransport/testSendChannelsDontBlock
--- PASS: TestTransport (0.09s)
    --- PASS: TestTransport/testStandardTransportBehaviour (0.09s)
    --- PASS: TestTransport/testSendChannelsDontBlock (0.00s)
=== RUN   TestReceive
--- PASS: TestReceive (0.01s)
=== RUN   TestSend
--- PASS: TestSend (0.01s)
PASS

```