### PR TITLE
nats: use github.com/nats-io/go-nats instead of github.com/nats-io/nats in tests

### DIFF
--- a/queues/nats/nats_test.go
+++ b/queues/nats/nats_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/matryer/is"
 	"github.com/matryer/vice"
 	"github.com/matryer/vice/vicetest"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 func TestTransport(t *testing.T) {


### PR DESCRIPTION
github.com/nats-io/go-nats is the new path.