### PR TITLE
redis: use redis as a queue instead of pub/sub

### DIFF
--- a/queues/redis/redis_test.go
+++ b/queues/redis/redis_test.go
@@ -73,7 +73,7 @@ func TestSubscriber(t *testing.T) {
 	<-waitChan
 
 	wg.Add(1)
-	cmd := client2.Publish("test_receive", string(msgToReceive))
+	cmd := client2.RPush("test_receive", string(msgToReceive))
 	is.NoErr(cmd.Err())
 	wg.Wait()
 	transport.Stop()

--- a/vicetest/test.go
+++ b/vicetest/test.go
@@ -21,17 +21,19 @@ import (
 // of the spec).
 func Transport(t *testing.T, transport func() vice.Transport) {
 	t.Run("testStandardTransportBehaviour", func(t *testing.T) {
-		testStandardTransportBehaviour(t, transport())
+		testStandardTransportBehaviour(t, transport)
 	})
 	t.Run("testSendChannelsDontBlock", func(t *testing.T) {
-		testSendChannelsDontBlock(t, transport())
+		testSendChannelsDontBlock(t, transport)
 	})
 }
 
 // testSendChannelsDontBlock ensures that send channels don't block, even
 // if nothing (we know of) is receiving them.
-func testSendChannelsDontBlock(t *testing.T, transport vice.Transport) {
+func testSendChannelsDontBlock(t *testing.T, newTransport func() vice.Transport) {
 	is := is.New(t)
+	transport := newTransport()
+
 	select {
 	case transport.Send("something") <- []byte("message"):
 		return
@@ -42,13 +44,17 @@ func testSendChannelsDontBlock(t *testing.T, transport vice.Transport) {
 
 // testStandardTransportBehaviour tests that transports load balance
 // over many Receive channels.
-func testStandardTransportBehaviour(t *testing.T, transport vice.Transport) {
+func testStandardTransportBehaviour(t *testing.T, newTransport func() vice.Transport) {
 	is := is.New(t)
 	defer func() {
 		if r := recover(); r != nil {
 			is.Fail("old messages may have confused test:", r)
 		}
 	}()
+
+	transport := newTransport()
+	transport1 := newTransport()
+	transport2 := newTransport()
 
 	doneChan := make(chan struct{})
 	messages := make(map[string][][]byte)
@@ -64,6 +70,7 @@ func testStandardTransportBehaviour(t *testing.T, transport vice.Transport) {
 			case err := <-transport.ErrChan():
 				is.NoErr(err)
 
+			// test local load balancing with the same transport
 			case msg := <-transport.Receive("vicechannel1"):
 				messages["vicechannel1"] = append(messages["vicechannel1"], msg)
 				wg.Done()
@@ -84,6 +91,17 @@ func testStandardTransportBehaviour(t *testing.T, transport vice.Transport) {
 			case msg := <-transport.Receive("vicechannel3"):
 				messages["vicechannel3"] = append(messages["vicechannel3"], msg)
 				wg.Done()
+
+			// test distibuted load balancing
+			case msg := <-transport.Receive("vicechannel4"):
+				messages["vicechannel4.1"] = append(messages["vicechannel4.1"], msg)
+				wg.Done()
+			case msg := <-transport1.Receive("vicechannel4"):
+				messages["vicechannel4.2"] = append(messages["vicechannel4.2"], msg)
+				wg.Done()
+			case msg := <-transport2.Receive("vicechannel4"):
+				messages["vicechannel4.3"] = append(messages["vicechannel4.3"], msg)
+				wg.Done()
 			}
 		}
 	}()
@@ -93,20 +111,28 @@ func testStandardTransportBehaviour(t *testing.T, transport vice.Transport) {
 
 	// send 100 messages down each chan
 	for i := 0; i < 100; i++ {
+		wg.Add(4)
 		msg := []byte(fmt.Sprintf("message %d", i+1))
-		wg.Add(3)
 		transport.Send("vicechannel1") <- msg
 		transport.Send("vicechannel2") <- msg
 		transport.Send("vicechannel3") <- msg
+		transport.Send("vicechannel4") <- msg
 	}
 
 	wg.Wait()
 	transport.Stop()
+	transport1.Stop()
+	transport2.Stop()
 	<-doneChan
 
-	is.Equal(len(messages), 3)
+	is.Equal(len(messages), 6)
 	is.Equal(len(messages["vicechannel1"]), 100)
 	is.Equal(len(messages["vicechannel2"]), 100)
 	is.Equal(len(messages["vicechannel3"]), 100)
 
+	is.NotEqual(len(messages["vicechannel4.1"]), 100)
+	is.NotEqual(len(messages["vicechannel4.2"]), 100)
+	is.NotEqual(len(messages["vicechannel4.3"]), 100)
+
+	is.Equal(len(messages["vicechannel4.1"])+len(messages["vicechannel4.2"])+len(messages["vicechannel4.3"]), 100)
 }


### PR DESCRIPTION
Implementation as described here: https://redis.io/commands/rpoplpush

I've also added a test to check if the transport behaves as a queue.

related to #19