### PR TITLE
added support for nats streaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ before_install:
   - nsqlookupd &
   - nsqd --lookupd-tcp-address=127.0.0.1:4160 &
   - nsqadmin --lookupd-http-address=127.0.0.1:4161 &
-  # install gnatsd
-  - wget https://github.com/nats-io/gnatsd/releases/download/v1.0.2/gnatsd-v1.0.2-linux-amd64.zip
-  - unzip -d gnatsd -j gnatsd-v1.0.2-linux-amd64.zip
-  - ./gnatsd/gnatsd &
+  # install gnatsd & nats-streaming
+  - wget https://github.com/nats-io/nats-streaming-server/releases/download/v0.5.0/nats-streaming-server-v0.5.0-linux-amd64.zip
+  - unzip -d gnatsd -j nats-streaming-server-v0.5.0-linux-amd64.zip
+  - ./gnatsd/nats-streaming-server &
 
 before_script:
   - go vet ./...
@@ -27,4 +27,4 @@ services:
   - redis
 
 script:
-  - go test -v ./...
+  - go test -v -race ./...

--- a/queues/nats/nats_test.go
+++ b/queues/nats/nats_test.go
@@ -9,11 +9,20 @@ import (
 	"github.com/matryer/vice"
 	"github.com/matryer/vice/vicetest"
 	"github.com/nats-io/go-nats"
+	"github.com/nats-io/go-nats-streaming"
+	uuid "github.com/satori/go.uuid"
 )
 
-func TestTransport(t *testing.T) {
+func TestDefaultTransport(t *testing.T) {
 	new := func() vice.Transport {
 		return New()
+	}
+
+	vicetest.Transport(t, new)
+}
+func TestStreamingTransport(t *testing.T) {
+	new := func() vice.Transport {
+		return New(WithStreaming("test-cluster", uuid.NewV4().String()))
 	}
 
 	vicetest.Transport(t, new)
@@ -23,23 +32,27 @@ func TestReceive(t *testing.T) {
 	is := is.New(t)
 
 	transport := New()
+	streamTransport := New(WithStreaming("test-cluster", uuid.NewV4().String()))
 
 	var wg sync.WaitGroup
 
 	go func() {
-
-		select {
-		case <-transport.Done():
-			return
-		case err := <-transport.ErrChan():
-			is.NoErr(err)
-		case msg := <-transport.Receive("test_receive"):
-			is.Equal(msg, []byte("hello vice"))
-			wg.Done()
-		case <-time.After(2 * time.Second):
-			is.Fail() // time out: transport.Receive
+		for {
+			select {
+			case <-transport.Done():
+				return
+			case err := <-transport.ErrChan():
+				is.NoErr(err)
+			case msg := <-transport.Receive("test_receive"):
+				is.Equal(msg, []byte("hello vice"))
+				wg.Done()
+			case msg := <-streamTransport.Receive("test_receive"):
+				is.Equal(msg, []byte("hello vice"))
+				wg.Done()
+			case <-time.After(2 * time.Second):
+				is.Fail() // time out: transport.Receive
+			}
 		}
-
 	}()
 
 	time.Sleep(time.Millisecond * 10)
@@ -49,12 +62,24 @@ func TestReceive(t *testing.T) {
 	if err != nil {
 		is.Fail() // couldn't connect to nats server
 	}
-	wg.Add(1)
+
+	ns, err := stan.Connect("test-cluster", "bla")
+	defer ns.Close()
+	if err != nil {
+		is.Fail() // couldn't connect to nats server
+	}
+
+	wg.Add(2)
 	err = nc.Publish("test_receive", []byte("hello vice"))
+	is.NoErr(err)
+	err = ns.Publish("test_receive", []byte("hello vice"))
 	is.NoErr(err)
 	wg.Wait()
 
 	transport.Stop()
+	<-transport.Done()
+
+	streamTransport.Stop()
 	<-transport.Done()
 }
 
@@ -62,40 +87,47 @@ func TestSend(t *testing.T) {
 	is := is.New(t)
 
 	transport := New()
+	streamTransport := New(WithStreaming("test-cluster", uuid.NewV4().String()))
 
 	var wg sync.WaitGroup
 
 	var msgs [][]byte
 
 	go func() {
-
-		select {
-		case <-transport.Done():
-			return
-		case err := <-transport.ErrChan():
-			is.NoErr(err)
-		case msg := <-transport.Receive("test_send"):
-			msgs = append(msgs, msg)
-			is.Equal(msg, []byte("hello vice"))
-			wg.Done()
-		case <-time.After(3 * time.Second):
-			is.Fail() // time out: transport.Receive
+		for {
+			select {
+			case <-transport.Done():
+				return
+			case err := <-transport.ErrChan():
+				is.NoErr(err)
+			case msg := <-transport.Receive("test_send"):
+				msgs = append(msgs, msg)
+				is.Equal(msg, []byte("hello vice"))
+				wg.Done()
+			case msg := <-streamTransport.Receive("test_send"):
+				msgs = append(msgs, msg)
+				is.Equal(msg, []byte("hello vice"))
+				wg.Done()
+			case <-time.After(3 * time.Second):
+				is.Fail() // time out: transport.Receive
+			}
 		}
-
 	}()
 
 	time.Sleep(time.Millisecond * 10)
-	wg.Add(1)
+	wg.Add(2)
 
-	select {
-	case transport.Send("test_send") <- []byte("hello vice"):
-	case <-time.After(2 * time.Second):
-		is.Fail() // time out: transport.Send
-	}
+	streamTransport.Send("test_send") <- []byte("hello vice")
+	transport.Send("test_send") <- []byte("hello vice")
+
 	wg.Wait()
-	transport.Stop()
 
-	is.Equal(len(msgs), 1)
+	is.Equal(len(msgs), 2)
 	is.Equal(transport.Send("test_send"), transport.Send("test_send"))
 	is.True(transport.Send("test_send") != transport.Send("different"))
+	is.Equal(streamTransport.Send("test_send"), streamTransport.Send("test_send"))
+	is.True(streamTransport.Send("test_send") != streamTransport.Send("different"))
+
+	transport.Stop()
+	streamTransport.Stop()
 }

--- a/queues/nats/options.go
+++ b/queues/nats/options.go
@@ -2,14 +2,29 @@ package nats
 
 import "github.com/nats-io/go-nats"
 
+// Options can be used to create a customized transport.
 type Options struct {
-	Conn *nats.Conn
+	Conn               *nats.Conn
+	StreamingClusterID string
+	StreamingClientID  string
+	UseStreaming       bool
 }
 
+// Option is a function on the options for a nats transport.
 type Option func(*Options)
 
+// WithConnection is an Option to set underlying nats connection.
 func WithConnection(c *nats.Conn) Option {
 	return func(o *Options) {
 		o.Conn = c
+	}
+}
+
+// WithStreaming is an Option to activate nats streaming for the transport.
+func WithStreaming(clusterID, clientID string) Option {
+	return func(o *Options) {
+		o.UseStreaming = true
+		o.StreamingClientID = clientID
+		o.StreamingClusterID = clusterID
 	}
 }


### PR DESCRIPTION
I've added support for nats-streaming to the nats queue implementation.
https://nats.io/documentation/streaming/nats-streaming-intro/

a new nats-streaming transport can easily be created with:  New(WithStreaming("clusterID", "clientID"))

```go
  1 package main
  2
  3 import (
  4         "fmt"
  5
  6         vn "github.com/matryer/vice/queues/nats"
  7 )
  8
  9 func main() {
 10         nt := vn.New(vn.WithStreaming("test-cluster", "test-id"))
 11         defer nt.Stop()
 12
 13         rc := nt.Receive("test123")
 14
 15         for {
 16                 select {
 17                 case v := <-rc:
 18                         fmt.Println(string(v))
 19                 case err := <-nt.ErrChan():
 20                         panic(err)
 21                 }
 22         }
 23 }

```
@matryer @piotrrojek what do you think?
