### PR TITLE
fix uncomparable types panic bug when consuming the vice Err type from the errChan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# jetbrains settings
+.idea/

--- a/queues/nats/nats.go
+++ b/queues/nats/nats.go
@@ -107,7 +107,7 @@ func (t *Transport) Receive(name string) <-chan []byte {
 
 	ch, err := t.makeSubscriber(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 
@@ -159,7 +159,7 @@ func (t *Transport) Send(name string) chan<- []byte {
 
 	ch, err := t.makePublisher(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 
@@ -199,7 +199,7 @@ func (t *Transport) makePublisher(name string) (chan []byte, error) {
 				return
 			case msg := <-ch:
 				if err := c.Publish(name, msg); err != nil {
-					t.errChan <- vice.Err{Message: msg, Name: name, Err: err}
+					t.errChan <- &vice.Err{Message: msg, Name: name, Err: err}
 					time.Sleep(1 * time.Second)
 				}
 			}

--- a/queues/nsq/nsq.go
+++ b/queues/nsq/nsq.go
@@ -90,7 +90,7 @@ func (t *Transport) Receive(name string) <-chan []byte {
 		// failed to make a consumer, so send an error down the
 		// ReceiveErrs channel and return an empty channel to
 		// avoid panic.
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 	t.receiveChans[name] = ch
@@ -136,7 +136,7 @@ func (t *Transport) Send(name string) chan<- []byte {
 		// failed to make a producer, send an error down the
 		// sendErrsChan and return an empty channel so we don't
 		// panic.
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 	t.sendChans[name] = ch
@@ -164,7 +164,7 @@ func (t *Transport) makeProducer(name string) (chan []byte, error) {
 					return producer.Publish(name, msg)
 				})
 				if err != nil {
-					t.errChan <- vice.Err{Message: msg, Name: name, Err: err}
+					t.errChan <- &vice.Err{Message: msg, Name: name, Err: err}
 					continue
 				}
 			}

--- a/queues/rabbitmq/rabbitmq.go
+++ b/queues/rabbitmq/rabbitmq.go
@@ -76,7 +76,7 @@ func (t *Transport) Receive(name string) <-chan []byte {
 
 	ch, err := t.makeSubscriber(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 
@@ -159,7 +159,7 @@ func (t *Transport) Send(name string) chan<- []byte {
 
 	ch, err := t.makePublisher(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 	t.sendChans[name] = ch
@@ -216,7 +216,7 @@ func (t *Transport) makePublisher(name string) (chan []byte, error) {
 						Body:         msg,
 					})
 				if err != nil {
-					t.errChan <- vice.Err{Message: msg, Name: name, Err: err}
+					t.errChan <- &vice.Err{Message: msg, Name: name, Err: err}
 				}
 			}
 		}

--- a/queues/redis/redis.go
+++ b/queues/redis/redis.go
@@ -75,7 +75,7 @@ func (t *Transport) Receive(name string) <-chan []byte {
 
 	ch, err := t.makeSubscriber(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 
@@ -98,7 +98,7 @@ func (t *Transport) makeSubscriber(name string) (chan []byte, error) {
 				case <-t.stopSubChan:
 					return
 				default:
-					t.errChan <- vice.Err{Name: name, Err: err}
+					t.errChan <- &vice.Err{Name: name, Err: err}
 					continue
 				}
 			}
@@ -122,7 +122,7 @@ func (t *Transport) Send(name string) chan<- []byte {
 
 	ch, err := t.makePublisher(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 	t.sendChans[name] = ch
@@ -152,7 +152,7 @@ func (t *Transport) makePublisher(name string) (chan []byte, error) {
 			case msg := <-ch:
 				err := c.RPush(name, string(msg)).Err()
 				if err != nil {
-					t.errChan <- vice.Err{Message: msg, Name: name, Err: err}
+					t.errChan <- &vice.Err{Message: msg, Name: name, Err: err}
 				}
 			}
 		}

--- a/queues/sqs/multi_writer.go
+++ b/queues/sqs/multi_writer.go
@@ -92,7 +92,7 @@ func (t *MultiTransport) Receive(name string) <-chan []byte {
 
 	ch, err := t.makeSubscriber(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 
@@ -124,7 +124,7 @@ func (t *MultiTransport) makeSubscriber(name string) (chan []byte, error) {
 			default:
 				resp, err := svc.ReceiveMessage(params)
 				if err != nil {
-					t.errChan <- vice.Err{Name: name, Err: err}
+					t.errChan <- &vice.Err{Name: name, Err: err}
 					continue
 				}
 
@@ -137,7 +137,7 @@ func (t *MultiTransport) makeSubscriber(name string) (chan []byte, error) {
 							}
 							_, err := svc.DeleteMessage(delParams)
 							if err != nil {
-								t.errChan <- vice.Err{Name: name, Err: err}
+								t.errChan <- &vice.Err{Name: name, Err: err}
 								continue
 							}
 						}
@@ -164,7 +164,7 @@ func (t *MultiTransport) Send(name string) chan<- []byte {
 
 	ch, err := t.makePublishers(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 
@@ -353,7 +353,7 @@ func (s *svcWriter) sendMessage(name string, msg sqs.SendMessageBatchRequestEntr
 		QueueUrl:    aws.String(name),
 	})
 	if err != nil {
-		s.errChan <- vice.Err{Message: []byte(*msg.MessageBody), Name: name, Err: err}
+		s.errChan <- &vice.Err{Message: []byte(*msg.MessageBody), Name: name, Err: err}
 	}
 }
 
@@ -374,11 +374,11 @@ func (s *svcWriter) sendBatch(name string, batch sendMsgBatch) {
 
 	resp, err := s.svc.SendMessageBatch(batchParams)
 	if err != nil {
-		s.errChan <- vice.Err{Name: name, Err: err}
+		s.errChan <- &vice.Err{Name: name, Err: err}
 		return
 	}
 
 	for _, v := range resp.Failed {
-		s.errChan <- vice.Err{Name: name, Err: fmt.Errorf("%s", *v.Message)}
+		s.errChan <- &vice.Err{Name: name, Err: fmt.Errorf("%s", *v.Message)}
 	}
 }

--- a/queues/sqs/sqs.go
+++ b/queues/sqs/sqs.go
@@ -82,7 +82,7 @@ func (t *Transport) Receive(name string) <-chan []byte {
 
 	ch, err := t.makeSubscriber(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 
@@ -124,7 +124,7 @@ func (t *Transport) makeSubscriber(name string) (chan []byte, error) {
 			default:
 				resp, err := svc.ReceiveMessage(params)
 				if err != nil {
-					t.errChan <- vice.Err{Name: name, Err: err}
+					t.errChan <- &vice.Err{Name: name, Err: err}
 					continue
 				}
 
@@ -137,7 +137,7 @@ func (t *Transport) makeSubscriber(name string) (chan []byte, error) {
 							}
 							_, err := svc.DeleteMessage(delParams)
 							if err != nil {
-								t.errChan <- vice.Err{Name: name, Err: err}
+								t.errChan <- &vice.Err{Name: name, Err: err}
 								continue
 							}
 						}
@@ -164,7 +164,7 @@ func (t *Transport) Send(name string) chan<- []byte {
 
 	ch, err := t.makePublisher(name)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return make(chan []byte)
 	}
 
@@ -210,7 +210,7 @@ func (t *Transport) makePublisher(name string) (chan []byte, error) {
 					}
 					_, err := svc.SendMessage(params)
 					if err != nil {
-						t.errChan <- vice.Err{Message: msg, Name: name, Err: err}
+						t.errChan <- &vice.Err{Message: msg, Name: name, Err: err}
 					}
 					continue
 				}
@@ -248,13 +248,13 @@ func (t *Transport) sendBatch(svc sqsiface.SQSAPI, name string, entries []*sqs.S
 
 	resp, err := svc.SendMessageBatch(batchParams)
 	if err != nil {
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 		return
 	}
 
 	for _, v := range resp.Failed {
 		err := fmt.Errorf("%s", *v.Message)
-		t.errChan <- vice.Err{Name: name, Err: err}
+		t.errChan <- &vice.Err{Name: name, Err: err}
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -31,7 +31,7 @@ type Err struct {
 	Err     error
 }
 
-func (e Err) Error() string {
+func (e *Err) Error() string {
 	if len(e.Message) > 0 {
 		return fmt.Sprintf("%s: |%s| <- `%s`", e.Err, e.Name, string(e.Message))
 	}


### PR DESCRIPTION
make Err type Error method a pointer receiver to avoid panics with uncomparable types

minimum code to reproduce this bug with the existing master branch Err implementation

```go
package main

import (
    "log"

    "github.com/matryer/vice"
    "github.com/pkg/errors"
)

func main() {
    err := vice.Err{Name: "foo", Err: errors.New("foo bar")}
    comp(&err) // alls well
    comp(err) // craps the bed here with uncompareable type panic
}

func comp(err error) {
    cause := errors.Cause(err)

    if cause != err {

        log.Println("foo bar")
    }
}
```