### PR TITLE
#52 update redis imports

### DIFF
--- a/queues/redis/options.go
+++ b/queues/redis/options.go
@@ -1,6 +1,6 @@
 package redis
 
-import "gopkg.in/redis.v3"
+import "github.com/go-redis/redis"
 
 type Options struct {
 	Client *redis.Client

--- a/queues/redis/redis.go
+++ b/queues/redis/redis.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-redis/redis"
 	"github.com/matryer/vice"
-	"gopkg.in/redis.v3"
 )
 
 // Transport is a vice.Transport for redis.


### PR DESCRIPTION
Update imports to point redis to current repository.  They stopped using gopkg.in