### PR TITLE
use nats.go and stan.go for importing

### DIFF
--- a/queues/nats/nats.go
+++ b/queues/nats/nats.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/matryer/vice"
-	"github.com/nats-io/go-nats"
-	"github.com/nats-io/go-nats-streaming"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/stan.go"
 )
 
 // DefaultAddr is the NATS default TCP address.

--- a/queues/nats/nats_test.go
+++ b/queues/nats/nats_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/matryer/is"
 	"github.com/matryer/vice"
 	"github.com/matryer/vice/vicetest"
-	"github.com/nats-io/go-nats"
-	"github.com/nats-io/go-nats-streaming"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/stan.go"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/queues/nats/options.go
+++ b/queues/nats/options.go
@@ -1,6 +1,6 @@
 package nats
 
-import "github.com/nats-io/go-nats"
+import "github.com/nats-io/nats.go"
 
 // Options can be used to create a customized transport.
 type Options struct {


### PR DESCRIPTION
nats.io changed there imports

this will fix build errors such as this one:
https://gopkgs.io/builds/20190511-011356-c6aba11f